### PR TITLE
added two use cases to **more than an editor

### DIFF
--- a/README.org
+++ b/README.org
@@ -52,6 +52,8 @@ And if you have an exotic operating system, here are the specific distributions:
   - Encrypt/decrypt files (like GPG files)
   - On-the-fly archives editing (thanks to [[http://www.emacswiki.org/emacs/ArchiveMode][archive-mode]])
   - PDF / Image / (...) viewer
+  - A powerful front end to R / S+ / SPSS / Stata (with [[http://ess.r-project.org/][EmacsSpeaksStatisics)]]
+  - An editor for multi-modal REPL's like IPython (with [[http://tkf.github.io/emacs-ipython-notebook/][EmacsIPythonNotebook]])
   - Music player (with emms, vlc, mplayer, ...)
   - Music programming (with [[http://vimeo.com/22798433][Overtone]])
   - Video editing


### PR DESCRIPTION
I added two use cases of which people may be unaware.  ESS provides a powerful front-end to the popular statistics language R.  R's own editor is terrible as many new students find out the hard way.  ESS does everything R studio can do plus a whole lot more.  Also, IPython is a very popular REPL within the Python community that was significantly enhanced by web client 2 years ago. The Emacs IPython notebook integrates that with a much richer set of editing features.
