### PR TITLE
Fixed typographical error, changed absolutly to absolutely in README.

### DIFF
--- a/README.org
+++ b/README.org
@@ -98,7 +98,7 @@ Contributors list can be found [[https://github.com/pierre-lecocq/emacs4develope
 
 * Thanks
 
-I want to thank some of the great people who make Emacs a very intersting piece of software or make its community very active (the sort order is absolutly not important here):
+I want to thank some of the great people who make Emacs a very intersting piece of software or make its community very active (the sort order is absolutely not important here):
 
 Bastien Guerry ([[https://twitter.com/bzg2][@bzg2]]), Dimitri Fontaine ([[https://twitter.com/tapoueh][@tapoueh]]), Julien Danjou ([[https://twitter.com/juldanjou][@juldanjou]]), Sacha Chua ([[https://twitter.com/sachac][@sachac]]), Steve Purcell ([[https://twitter.com/sanityinc][@sanityinc]]), Nic Ferrier ([[https://twitter.com/nicferrier][@nicferrier]]), Avdi Grimm ([[https://twitter.com/avdi][@avdi]]), Magnars ([[https://twitter.com/magnars][@magnars]]), Steve Yegge ([[https://twitter.com/Steve_Yegge][@Steve_Yegge]]), Bozhidar Batsov ([[https://twitter.com/bbatsov][@bbatsov]]), Xah Lee ([[https://twitter.com/xah_lee][@xah_lee]]), and many more ...
 


### PR DESCRIPTION
pierre-lecocq, I've corrected a typographical error in the documentation of the [emacs4developers](https://github.com/pierre-lecocq/emacs4developers) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.